### PR TITLE
Create web-based fleet management SPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# Flota-vehiculos
+# Gestión de Flota de Vehículos
+
+Aplicación web de una sola página (SPA) para gestionar la operación diaria de una flota de vehículos. Permite administrar conductores, vehículos, movimientos, carguíos de combustible y mantenimientos desde un panel centralizado que funciona completamente en el navegador.
+
+## Características principales
+
+- **Autenticación básica** con un usuario demo (`admin` / `admin123`).
+- **Panel de control** con métricas clave y actividades recientes.
+- **Módulo de conductores** para registrar información de contacto y licencias.
+- **Módulo de vehículos** con estado operativo, capacidad y datos técnicos.
+- **Movimientos de flota** para controlar salidas, llegadas y responsables.
+- **Carguíos de combustible** con litros consumidos, costo y estación de servicio.
+- **Mantenimientos programados** con seguimiento del próximo servicio.
+- **Persistencia local** usando `localStorage`, ideal para prototipos sin backend.
+
+## Cómo usarla
+
+1. Abre el archivo `index.html` en tu navegador preferido.
+2. Inicia sesión con las credenciales demo: `admin` / `admin123`.
+3. Navega por el panel usando las pestañas de la barra superior.
+4. Utiliza los botones “Nuevo” o “Registrar” para agregar información. Cada formulario permite crear y editar registros.
+5. Los datos quedan almacenados en el navegador (`localStorage`). Puedes limpiarlos desde las herramientas del navegador si deseas volver al estado inicial con los datos de ejemplo.
+
+## Tecnología utilizada
+
+- HTML5 y CSS3 con un diseño adaptable.
+- JavaScript moderno (ES Modules) sin dependencias externas.
+- Uso de componentes nativos (`<dialog>`) para modales y formularios.
+
+## Estructura del proyecto
+
+```
+.
+├── index.html       # Contenedor principal de la aplicación
+├── css/
+│   └── styles.css   # Estilos globales y de componentes
+└── js/
+    └── app.js       # Lógica de negocio y manejo de datos
+```
+
+## Personalización y despliegue
+
+- Para modificar los datos iniciales ajusta la función `createSeedData` en `js/app.js`.
+- Puedes desplegar la aplicación en cualquier servicio de hosting estático (GitHub Pages, Netlify, Vercel, etc.).
+- Si deseas conectarla con un backend real, reemplaza la capa de persistencia (`localStorage`) por llamadas a una API.

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,332 @@
+:root {
+    --color-bg: #f5f7fb;
+    --color-surface: #ffffff;
+    --color-border: #d8dee9;
+    --color-primary: #2563eb;
+    --color-primary-dark: #1d4ed8;
+    --color-text: #1f2937;
+    --color-muted: #6b7280;
+    --color-success: #059669;
+    --color-danger: #dc2626;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: var(--color-bg);
+    color: var(--color-text);
+}
+
+main {
+    min-height: 100vh;
+    padding: 3rem 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+h1, h2, h3 {
+    margin: 0 0 0.5rem;
+}
+
+.subtitle {
+    color: var(--color-muted);
+    margin-top: 0;
+}
+
+.card {
+    background: var(--color-surface);
+    padding: 2rem;
+    border-radius: 1rem;
+    max-width: 440px;
+    width: 100%;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.1);
+}
+
+.form {
+    display: grid;
+    gap: 1rem;
+}
+
+.form-group label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}
+
+input, select, textarea, button {
+    font: inherit;
+}
+
+input, select, textarea {
+    width: 100%;
+    padding: 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    background: #f9fafb;
+}
+
+textarea {
+    resize: vertical;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    border-radius: 999px;
+    border: none;
+    background: var(--color-border);
+    color: var(--color-text);
+    cursor: pointer;
+    font-weight: 600;
+    transition: transform 0.1s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+}
+
+.btn.primary {
+    background: var(--color-primary);
+    color: white;
+}
+
+.btn.primary:hover {
+    background: var(--color-primary-dark);
+}
+
+.hint {
+    text-align: center;
+    color: var(--color-muted);
+    margin: 0;
+}
+
+.error {
+    color: var(--color-danger);
+    text-align: center;
+    margin: 0;
+}
+
+.hidden {
+    display: none !important;
+}
+
+#dashboard {
+    max-width: 1200px;
+    width: 100%;
+    display: grid;
+    gap: 1.5rem;
+}
+
+.topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.topbar-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+}
+
+.navbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.nav-link {
+    border: none;
+    background: transparent;
+    color: var(--color-muted);
+    padding: 0.75rem 1.5rem;
+    border-radius: 999px;
+    cursor: pointer;
+    font-weight: 600;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-link.active {
+    background: var(--color-primary);
+    color: white;
+}
+
+.page {
+    background: var(--color-surface);
+    padding: 1.5rem;
+    border-radius: 1.25rem;
+    box-shadow: 0 15px 30px rgba(15, 23, 42, 0.08);
+}
+
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.stat-card {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.1), rgba(37, 99, 235, 0));
+    border: 1px solid rgba(37, 99, 235, 0.2);
+    border-radius: 1.25rem;
+    padding: 1.5rem;
+}
+
+.stat-card h3 {
+    color: var(--color-muted);
+    font-size: 0.95rem;
+}
+
+.stat-value {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin: 0;
+}
+
+.activity-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.activity-list li {
+    background: #f3f4f6;
+    padding: 1rem;
+    border-radius: 0.75rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+    padding: 0.75rem 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid var(--color-border);
+    vertical-align: top;
+}
+
+.data-table th {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-muted);
+}
+
+.data-table tbody tr:hover {
+    background: #f9fafb;
+}
+
+.actions {
+    white-space: nowrap;
+    text-align: right;
+}
+
+.icon-btn {
+    border: none;
+    background: transparent;
+    font-size: 1.1rem;
+    cursor: pointer;
+    margin-left: 0.25rem;
+}
+
+.icon-btn:hover {
+    transform: scale(1.1);
+}
+
+.modal::backdrop {
+    background: rgba(15, 23, 42, 0.45);
+}
+
+.modal {
+    border: none;
+    border-radius: 1.25rem;
+    padding: 0;
+    max-width: 640px;
+    width: 100%;
+}
+
+.modal-content {
+    display: grid;
+    gap: 1rem;
+    padding: 1.5rem;
+}
+
+.modal-content header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.form-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form-grid label {
+    display: grid;
+    gap: 0.35rem;
+    font-weight: 600;
+}
+
+.modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+}
+
+@media (max-width: 960px) {
+    main {
+        padding: 2rem 1rem;
+    }
+
+    .topbar {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .topbar-actions {
+        align-items: flex-start;
+    }
+}
+
+@media (max-width: 640px) {
+    .page {
+        padding: 1rem;
+    }
+
+    .navbar {
+        overflow-x: auto;
+    }
+
+    .stats-grid {
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,359 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gestión de Flota de Vehículos</title>
+    <link rel="stylesheet" href="css/styles.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <main id="app">
+        <section id="login-section" class="card">
+            <h1>Gestión de Flota</h1>
+            <p class="subtitle">Inicia sesión para administrar tu flota de vehículos.</p>
+            <form id="login-form" class="form">
+                <div class="form-group">
+                    <label for="username">Usuario</label>
+                    <input type="text" id="username" name="username" required autofocus>
+                </div>
+                <div class="form-group">
+                    <label for="password">Contraseña</label>
+                    <input type="password" id="password" name="password" required>
+                </div>
+                <button type="submit" class="btn primary">Iniciar sesión</button>
+                <p class="hint">Usuario demo: <strong>admin</strong> / Contraseña: <strong>admin123</strong></p>
+                <p id="login-error" class="error hidden">Credenciales inválidas, intenta nuevamente.</p>
+            </form>
+        </section>
+
+        <div id="dashboard" class="hidden">
+            <header class="topbar">
+                <div>
+                    <h1>Panel de Gestión de Flota</h1>
+                    <p class="subtitle">Control centralizado de conductores, vehículos y operaciones diarias.</p>
+                </div>
+                <div class="topbar-actions">
+                    <span id="welcome-text"></span>
+                    <button id="logout-btn" class="btn">Cerrar sesión</button>
+                </div>
+            </header>
+
+            <nav class="navbar">
+                <button class="nav-link active" data-target="resumen">Resumen</button>
+                <button class="nav-link" data-target="conductores">Conductores</button>
+                <button class="nav-link" data-target="vehiculos">Vehículos</button>
+                <button class="nav-link" data-target="movimientos">Movimientos</button>
+                <button class="nav-link" data-target="carguios">Carguíos de Combustible</button>
+                <button class="nav-link" data-target="mantenimientos">Mantenimientos</button>
+            </nav>
+
+            <section id="resumen" class="page">
+                <h2>Resumen</h2>
+                <div class="stats-grid">
+                    <article class="stat-card">
+                        <h3>Conductores activos</h3>
+                        <p id="stat-drivers" class="stat-value">0</p>
+                    </article>
+                    <article class="stat-card">
+                        <h3>Vehículos en servicio</h3>
+                        <p id="stat-vehicles" class="stat-value">0</p>
+                    </article>
+                    <article class="stat-card">
+                        <h3>Movimientos registrados (30 días)</h3>
+                        <p id="stat-movements" class="stat-value">0</p>
+                    </article>
+                    <article class="stat-card">
+                        <h3>Próximos mantenimientos</h3>
+                        <p id="stat-maintenance" class="stat-value">0</p>
+                    </article>
+                </div>
+                <section class="card">
+                    <h3>Indicadores recientes</h3>
+                    <ul id="recent-activity" class="activity-list"></ul>
+                </section>
+            </section>
+
+            <section id="conductores" class="page hidden">
+                <div class="page-header">
+                    <h2>Conductores</h2>
+                    <button class="btn primary" data-open-modal="driver-modal">Nuevo conductor</button>
+                </div>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Nombre</th>
+                            <th>Número de licencia</th>
+                            <th>Teléfono</th>
+                            <th>Email</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody id="drivers-table" data-entity="drivers"></tbody>
+                </table>
+            </section>
+
+            <section id="vehiculos" class="page hidden">
+                <div class="page-header">
+                    <h2>Vehículos</h2>
+                    <button class="btn primary" data-open-modal="vehicle-modal">Nuevo vehículo</button>
+                </div>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Patente</th>
+                            <th>Marca</th>
+                            <th>Modelo</th>
+                            <th>Año</th>
+                            <th>Capacidad</th>
+                            <th>Estado</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody id="vehicles-table" data-entity="vehicles"></tbody>
+                </table>
+            </section>
+
+            <section id="movimientos" class="page hidden">
+                <div class="page-header">
+                    <h2>Movimientos</h2>
+                    <button class="btn primary" data-open-modal="movement-modal">Registrar movimiento</button>
+                </div>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Vehículo</th>
+                            <th>Conductor</th>
+                            <th>Origen</th>
+                            <th>Destino</th>
+                            <th>Salida</th>
+                            <th>Llegada</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody id="movements-table" data-entity="movements"></tbody>
+                </table>
+            </section>
+
+            <section id="carguios" class="page hidden">
+                <div class="page-header">
+                    <h2>Carguíos de combustible</h2>
+                    <button class="btn primary" data-open-modal="fuel-modal">Registrar carguío</button>
+                </div>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Vehículo</th>
+                            <th>Conductor</th>
+                            <th>Fecha</th>
+                            <th>Litros</th>
+                            <th>Costo</th>
+                            <th>Estación</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody id="fuel-table" data-entity="fuel"></tbody>
+                </table>
+            </section>
+
+            <section id="mantenimientos" class="page hidden">
+                <div class="page-header">
+                    <h2>Mantenimientos</h2>
+                    <button class="btn primary" data-open-modal="maintenance-modal">Registrar mantenimiento</button>
+                </div>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Vehículo</th>
+                            <th>Fecha</th>
+                            <th>Tipo</th>
+                            <th>Descripción</th>
+                            <th>Costo</th>
+                            <th>Próximo</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody id="maintenance-table" data-entity="maintenance"></tbody>
+                </table>
+            </section>
+        </div>
+    </main>
+
+    <div id="modals">
+        <dialog id="driver-modal" class="modal">
+            <form method="dialog" class="modal-content" data-entity="drivers">
+                <header>
+                    <h3 id="driver-modal-title">Nuevo conductor</h3>
+                    <button type="button" class="icon-btn" data-close>&times;</button>
+                </header>
+                <input type="hidden" name="id">
+                <div class="form-grid">
+                    <label>Nombre
+                        <input name="name" required>
+                    </label>
+                    <label>Número de licencia
+                        <input name="licenseNumber" required>
+                    </label>
+                    <label>Teléfono
+                        <input name="phone" required>
+                    </label>
+                    <label>Email
+                        <input name="email" type="email" required>
+                    </label>
+                </div>
+                <footer class="modal-footer">
+                    <button type="button" class="btn" data-close>Cancelar</button>
+                    <button type="submit" class="btn primary">Guardar</button>
+                </footer>
+            </form>
+        </dialog>
+
+        <dialog id="vehicle-modal" class="modal">
+            <form method="dialog" class="modal-content" data-entity="vehicles">
+                <header>
+                    <h3 id="vehicle-modal-title">Nuevo vehículo</h3>
+                    <button type="button" class="icon-btn" data-close>&times;</button>
+                </header>
+                <input type="hidden" name="id">
+                <div class="form-grid">
+                    <label>Patente
+                        <input name="plate" required>
+                    </label>
+                    <label>Marca
+                        <input name="brand" required>
+                    </label>
+                    <label>Modelo
+                        <input name="model" required>
+                    </label>
+                    <label>Año
+                        <input name="year" type="number" min="1950" max="2100" required>
+                    </label>
+                    <label>Capacidad
+                        <input name="capacity" required>
+                    </label>
+                    <label>Estado
+                        <select name="status" required>
+                            <option value="en_servicio">En servicio</option>
+                            <option value="mantenimiento">En mantenimiento</option>
+                            <option value="fuera_servicio">Fuera de servicio</option>
+                        </select>
+                    </label>
+                </div>
+                <footer class="modal-footer">
+                    <button type="button" class="btn" data-close>Cancelar</button>
+                    <button type="submit" class="btn primary">Guardar</button>
+                </footer>
+            </form>
+        </dialog>
+
+        <dialog id="movement-modal" class="modal">
+            <form method="dialog" class="modal-content" data-entity="movements">
+                <header>
+                    <h3 id="movement-modal-title">Registrar movimiento</h3>
+                    <button type="button" class="icon-btn" data-close>&times;</button>
+                </header>
+                <input type="hidden" name="id">
+                <div class="form-grid">
+                    <label>Vehículo
+                        <select name="vehicleId" required></select>
+                    </label>
+                    <label>Conductor
+                        <select name="driverId" required></select>
+                    </label>
+                    <label>Origen
+                        <input name="origin" required>
+                    </label>
+                    <label>Destino
+                        <input name="destination" required>
+                    </label>
+                    <label>Fecha de salida
+                        <input name="departureDate" type="datetime-local" required>
+                    </label>
+                    <label>Fecha de llegada
+                        <input name="arrivalDate" type="datetime-local">
+                    </label>
+                    <label>Notas
+                        <textarea name="notes" rows="2"></textarea>
+                    </label>
+                </div>
+                <footer class="modal-footer">
+                    <button type="button" class="btn" data-close>Cancelar</button>
+                    <button type="submit" class="btn primary">Guardar</button>
+                </footer>
+            </form>
+        </dialog>
+
+        <dialog id="fuel-modal" class="modal">
+            <form method="dialog" class="modal-content" data-entity="fuel">
+                <header>
+                    <h3 id="fuel-modal-title">Registrar carguío</h3>
+                    <button type="button" class="icon-btn" data-close>&times;</button>
+                </header>
+                <input type="hidden" name="id">
+                <div class="form-grid">
+                    <label>Vehículo
+                        <select name="vehicleId" required></select>
+                    </label>
+                    <label>Conductor
+                        <select name="driverId"></select>
+                    </label>
+                    <label>Fecha
+                        <input name="date" type="date" required>
+                    </label>
+                    <label>Litros
+                        <input name="liters" type="number" min="0" step="0.01" required>
+                    </label>
+                    <label>Costo
+                        <input name="cost" type="number" min="0" step="0.01" required>
+                    </label>
+                    <label>Estación
+                        <input name="station">
+                    </label>
+                </div>
+                <footer class="modal-footer">
+                    <button type="button" class="btn" data-close>Cancelar</button>
+                    <button type="submit" class="btn primary">Guardar</button>
+                </footer>
+            </form>
+        </dialog>
+
+        <dialog id="maintenance-modal" class="modal">
+            <form method="dialog" class="modal-content" data-entity="maintenance">
+                <header>
+                    <h3 id="maintenance-modal-title">Registrar mantenimiento</h3>
+                    <button type="button" class="icon-btn" data-close>&times;</button>
+                </header>
+                <input type="hidden" name="id">
+                <div class="form-grid">
+                    <label>Vehículo
+                        <select name="vehicleId" required></select>
+                    </label>
+                    <label>Fecha
+                        <input name="date" type="date" required>
+                    </label>
+                    <label>Tipo
+                        <input name="type" required>
+                    </label>
+                    <label>Descripción
+                        <textarea name="description" rows="3"></textarea>
+                    </label>
+                    <label>Costo
+                        <input name="cost" type="number" min="0" step="0.01">
+                    </label>
+                    <label>Próximo mantenimiento
+                        <input name="nextDate" type="date">
+                    </label>
+                </div>
+                <footer class="modal-footer">
+                    <button type="button" class="btn" data-close>Cancelar</button>
+                    <button type="submit" class="btn primary">Guardar</button>
+                </footer>
+            </form>
+        </dialog>
+    </div>
+
+    <script src="js/app.js" type="module"></script>
+</body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,772 @@
+const STORAGE_KEY = 'fleet-manager-data-v1';
+const SESSION_KEY = 'fleet-manager-session-v1';
+const STATUS_LABELS = {
+    en_servicio: 'En servicio',
+    mantenimiento: 'En mantenimiento',
+    fuera_servicio: 'Fuera de servicio'
+};
+
+const seedData = createSeedData();
+let state = loadState();
+let session = loadSession();
+
+const dom = {
+    loginSection: document.getElementById('login-section'),
+    loginForm: document.getElementById('login-form'),
+    loginError: document.getElementById('login-error'),
+    dashboard: document.getElementById('dashboard'),
+    welcomeText: document.getElementById('welcome-text'),
+    logoutBtn: document.getElementById('logout-btn'),
+    navLinks: Array.from(document.querySelectorAll('.nav-link')),
+    pages: Array.from(document.querySelectorAll('.page')),
+    stats: {
+        drivers: document.getElementById('stat-drivers'),
+        vehicles: document.getElementById('stat-vehicles'),
+        movements: document.getElementById('stat-movements'),
+        maintenance: document.getElementById('stat-maintenance')
+    },
+    recentActivity: document.getElementById('recent-activity')
+};
+
+const entityConfig = {
+    drivers: {
+        table: document.getElementById('drivers-table'),
+        modal: document.getElementById('driver-modal'),
+        title: document.getElementById('driver-modal-title'),
+        newTitle: 'Nuevo conductor',
+        editTitle: 'Editar conductor',
+        emptyMessage: 'No hay conductores registrados.',
+        columnCount: 4,
+        toForm: (item = {}) => ({
+            name: item.name || '',
+            licenseNumber: item.licenseNumber || '',
+            phone: item.phone || '',
+            email: item.email || ''
+        }),
+        serialize: formData => ({
+            name: formData.get('name').trim(),
+            licenseNumber: formData.get('licenseNumber').trim(),
+            phone: formData.get('phone').trim(),
+            email: formData.get('email').trim()
+        }),
+        columns: driver => [
+            driver.name,
+            driver.licenseNumber,
+            driver.phone,
+            driver.email
+        ]
+    },
+    vehicles: {
+        table: document.getElementById('vehicles-table'),
+        modal: document.getElementById('vehicle-modal'),
+        title: document.getElementById('vehicle-modal-title'),
+        newTitle: 'Nuevo vehículo',
+        editTitle: 'Editar vehículo',
+        emptyMessage: 'No hay vehículos registrados.',
+        columnCount: 6,
+        toForm: (item = {}) => ({
+            plate: item.plate || '',
+            brand: item.brand || '',
+            model: item.model || '',
+            year: item.year || '',
+            capacity: item.capacity || '',
+            status: item.status || 'en_servicio'
+        }),
+        serialize: formData => ({
+            plate: formData.get('plate').trim(),
+            brand: formData.get('brand').trim(),
+            model: formData.get('model').trim(),
+            year: Number(formData.get('year')) || new Date().getFullYear(),
+            capacity: formData.get('capacity').trim(),
+            status: formData.get('status')
+        }),
+        columns: vehicle => [
+            vehicle.plate,
+            vehicle.brand,
+            vehicle.model,
+            vehicle.year,
+            vehicle.capacity,
+            STATUS_LABELS[vehicle.status] || vehicle.status
+        ]
+    },
+    movements: {
+        table: document.getElementById('movements-table'),
+        modal: document.getElementById('movement-modal'),
+        title: document.getElementById('movement-modal-title'),
+        newTitle: 'Registrar movimiento',
+        editTitle: 'Editar movimiento',
+        emptyMessage: 'No hay movimientos registrados.',
+        columnCount: 6,
+        toForm: (item = {}) => ({
+            vehicleId: item.vehicleId || '',
+            driverId: item.driverId || '',
+            origin: item.origin || '',
+            destination: item.destination || '',
+            departureDate: item.departureDate || '',
+            arrivalDate: item.arrivalDate || '',
+            notes: item.notes || ''
+        }),
+        serialize: formData => ({
+            vehicleId: formData.get('vehicleId'),
+            driverId: formData.get('driverId'),
+            origin: formData.get('origin').trim(),
+            destination: formData.get('destination').trim(),
+            departureDate: formData.get('departureDate'),
+            arrivalDate: formData.get('arrivalDate') || '',
+            notes: formData.get('notes').trim()
+        }),
+        columns: movement => [
+            getVehicleName(movement.vehicleId),
+            getDriverName(movement.driverId),
+            movement.origin,
+            movement.destination,
+            formatDateTime(movement.departureDate),
+            movement.arrivalDate ? formatDateTime(movement.arrivalDate) : 'Pendiente'
+        ]
+    },
+    fuel: {
+        table: document.getElementById('fuel-table'),
+        modal: document.getElementById('fuel-modal'),
+        title: document.getElementById('fuel-modal-title'),
+        newTitle: 'Registrar carguío',
+        editTitle: 'Editar carguío',
+        emptyMessage: 'No hay carguíos registrados.',
+        columnCount: 6,
+        toForm: (item = {}) => ({
+            vehicleId: item.vehicleId || '',
+            driverId: item.driverId || '',
+            date: item.date || '',
+            liters: item.liters ?? '',
+            cost: item.cost ?? '',
+            station: item.station || ''
+        }),
+        serialize: formData => ({
+            vehicleId: formData.get('vehicleId'),
+            driverId: formData.get('driverId') || '',
+            date: formData.get('date'),
+            liters: Number(formData.get('liters')) || 0,
+            cost: Number(formData.get('cost')) || 0,
+            station: formData.get('station').trim()
+        }),
+        columns: fuel => [
+            getVehicleName(fuel.vehicleId),
+            fuel.driverId ? getDriverName(fuel.driverId) : 'No registrado',
+            formatDate(fuel.date),
+            `${fuel.liters.toLocaleString('es-ES', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} L`,
+            formatCurrency(fuel.cost),
+            fuel.station || '—'
+        ]
+    },
+    maintenance: {
+        table: document.getElementById('maintenance-table'),
+        modal: document.getElementById('maintenance-modal'),
+        title: document.getElementById('maintenance-modal-title'),
+        newTitle: 'Registrar mantenimiento',
+        editTitle: 'Editar mantenimiento',
+        emptyMessage: 'No hay mantenimientos registrados.',
+        columnCount: 6,
+        toForm: (item = {}) => ({
+            vehicleId: item.vehicleId || '',
+            date: item.date || '',
+            type: item.type || '',
+            description: item.description || '',
+            cost: item.cost ?? '',
+            nextDate: item.nextDate || ''
+        }),
+        serialize: formData => ({
+            vehicleId: formData.get('vehicleId'),
+            date: formData.get('date'),
+            type: formData.get('type').trim(),
+            description: formData.get('description').trim(),
+            cost: Number(formData.get('cost')) || 0,
+            nextDate: formData.get('nextDate') || ''
+        }),
+        columns: maintenance => [
+            getVehicleName(maintenance.vehicleId),
+            formatDate(maintenance.date),
+            maintenance.type,
+            maintenance.description || '—',
+            maintenance.cost ? formatCurrency(maintenance.cost) : '—',
+            maintenance.nextDate ? formatDate(maintenance.nextDate) : '—'
+        ]
+    }
+};
+
+document.querySelectorAll('tbody[data-entity]').forEach(tbody => {
+    tbody.addEventListener('click', handleTableAction);
+});
+
+document.querySelectorAll('[data-open-modal]').forEach(button => {
+    button.addEventListener('click', () => openEntityModal(button.dataset.openModal));
+});
+
+document.querySelectorAll('[data-close]').forEach(button => {
+    button.addEventListener('click', event => {
+        event.preventDefault();
+        const dialog = button.closest('dialog');
+        if (dialog) {
+            closeDialog(dialog);
+        }
+    });
+});
+
+document.querySelectorAll('dialog form[data-entity]').forEach(form => {
+    form.addEventListener('submit', handleEntitySubmit);
+    const dialog = form.closest('dialog');
+    if (dialog) {
+        dialog.addEventListener('close', () => form.reset());
+    }
+});
+
+dom.loginForm.addEventListener('submit', handleLogin);
+dom.logoutBtn.addEventListener('click', handleLogout);
+
+dom.navLinks.forEach(link => {
+    link.addEventListener('click', () => switchPage(link.dataset.target));
+});
+
+initializeApp();
+
+function initializeApp() {
+    if (session?.username) {
+        showDashboard(session.username);
+    } else {
+        showLogin();
+    }
+}
+
+function handleLogin(event) {
+    event.preventDefault();
+    const formData = new FormData(dom.loginForm);
+    const username = formData.get('username').trim();
+    const password = formData.get('password').trim();
+
+    if (authenticate(username, password)) {
+        dom.loginError.classList.add('hidden');
+        session = { username };
+        saveSession(session);
+        showDashboard(username);
+        dom.loginForm.reset();
+    } else {
+        dom.loginError.classList.remove('hidden');
+    }
+}
+
+function authenticate(username, password) {
+    const demoUser = { username: 'admin', password: 'admin123' };
+    return username === demoUser.username && password === demoUser.password;
+}
+
+function handleLogout() {
+    session = null;
+    localStorage.removeItem(SESSION_KEY);
+    showLogin();
+}
+
+function showLogin() {
+    dom.loginSection.classList.remove('hidden');
+    dom.dashboard.classList.add('hidden');
+}
+
+function showDashboard(username) {
+    dom.loginSection.classList.add('hidden');
+    dom.dashboard.classList.remove('hidden');
+    dom.welcomeText.textContent = `Bienvenido, ${username}`;
+    switchPage('resumen');
+    renderAll();
+}
+
+function switchPage(targetId) {
+    dom.pages.forEach(page => {
+        if (page.id === targetId) {
+            page.classList.remove('hidden');
+        } else {
+            page.classList.add('hidden');
+        }
+    });
+
+    dom.navLinks.forEach(link => {
+        if (link.dataset.target === targetId) {
+            link.classList.add('active');
+        } else {
+            link.classList.remove('active');
+        }
+    });
+}
+
+function openEntityModal(modalId, itemId = null) {
+    const entity = getEntityByModalId(modalId);
+    if (!entity) return;
+
+    const config = entityConfig[entity];
+    const modal = config.modal;
+    const form = modal.querySelector('form');
+    const currentItem = itemId ? state[entity].find(item => item.id === itemId) : null;
+
+    populateForm(form, entity, currentItem);
+
+    form.querySelector('input[name="id"]').value = currentItem?.id || '';
+    config.title.textContent = currentItem ? config.editTitle : config.newTitle;
+
+    modal.showModal();
+}
+
+function populateForm(form, entity, item) {
+    form.reset();
+    populateRelatedSelects(form, entity);
+
+    const values = entityConfig[entity].toForm(item);
+    Object.entries(values).forEach(([field, value]) => {
+        if (form.elements[field] !== undefined) {
+            form.elements[field].value = value;
+        }
+    });
+}
+
+function populateRelatedSelects(form, entity) {
+    if (entity === 'movements' || entity === 'fuel' || entity === 'maintenance') {
+        fillSelect(form.elements.vehicleId, state.vehicles, 'Selecciona un vehículo', vehicle => ({
+            value: vehicle.id,
+            label: `${vehicle.plate} · ${vehicle.brand} ${vehicle.model}`
+        }));
+    }
+
+    if (entity === 'movements' || entity === 'fuel') {
+        fillSelect(form.elements.driverId, state.drivers, 'Selecciona un conductor', driver => ({
+            value: driver.id,
+            label: `${driver.name} · Licencia ${driver.licenseNumber}`
+        }), entity === 'fuel');
+    }
+}
+
+function fillSelect(select, options, placeholder, mapFn, allowEmpty = false) {
+    if (!select) return;
+    select.innerHTML = '';
+
+    if (placeholder && !allowEmpty) {
+        const option = document.createElement('option');
+        option.value = '';
+        option.textContent = placeholder;
+        option.disabled = true;
+        option.selected = true;
+        select.append(option);
+    }
+
+    if (allowEmpty) {
+        const option = document.createElement('option');
+        option.value = '';
+        option.textContent = 'No registrado';
+        select.append(option);
+    }
+
+    options.forEach(optionData => {
+        const option = document.createElement('option');
+        const { value, label } = mapFn(optionData);
+        option.value = value;
+        option.textContent = label;
+        select.append(option);
+    });
+}
+
+function handleEntitySubmit(event) {
+    event.preventDefault();
+    const form = event.target;
+    const entity = form.dataset.entity;
+    const config = entityConfig[entity];
+    const formData = new FormData(form);
+    const id = formData.get('id');
+    const payload = config.serialize(formData);
+
+    if (id) {
+        updateEntity(entity, id, payload);
+    } else {
+        createEntity(entity, payload);
+    }
+
+    closeDialog(form.closest('dialog'));
+    renderAll();
+}
+
+function handleTableAction(event) {
+    const button = event.target.closest('button[data-action]');
+    if (!button) return;
+
+    const action = button.dataset.action;
+    const row = button.closest('tr');
+    const tbody = button.closest('tbody');
+    if (!row || !tbody) return;
+
+    const entity = tbody.dataset.entity;
+    const id = row.dataset.id;
+
+    if (action === 'edit') {
+        openEntityModal(entityConfig[entity].modal.id, id);
+    } else if (action === 'delete') {
+        const confirmation = confirm('¿Deseas eliminar este registro?');
+        if (confirmation) {
+            deleteEntity(entity, id);
+            renderAll();
+        }
+    }
+}
+
+function createEntity(entity, payload) {
+    const item = {
+        id: generateId(),
+        createdAt: new Date().toISOString(),
+        ...payload
+    };
+    state[entity].push(item);
+    persistState();
+    return item;
+}
+
+function updateEntity(entity, id, payload) {
+    const items = state[entity];
+    const index = items.findIndex(item => item.id === id);
+    if (index === -1) return null;
+
+    items[index] = {
+        ...items[index],
+        ...payload,
+        updatedAt: new Date().toISOString()
+    };
+    persistState();
+    return items[index];
+}
+
+function deleteEntity(entity, id) {
+    state[entity] = state[entity].filter(item => item.id !== id);
+    persistState();
+}
+
+function renderAll() {
+    renderTables();
+    renderStats();
+    renderRecentActivity();
+}
+
+function renderTables() {
+    Object.entries(entityConfig).forEach(([entity, config]) => {
+        const items = state[entity];
+        renderTable(config.table, items, config.columns, config.columnCount, config.emptyMessage);
+    });
+}
+
+function renderTable(tbody, items, getColumns, columnCount, emptyMessage) {
+    tbody.innerHTML = '';
+    if (!items.length) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = columnCount + 1;
+        cell.textContent = emptyMessage;
+        cell.style.textAlign = 'center';
+        cell.style.color = 'var(--color-muted)';
+        row.append(cell);
+        tbody.append(row);
+        return;
+    }
+
+    const sortedItems = [...items].sort((a, b) => {
+        const dateA = new Date(a.createdAt || 0).getTime();
+        const dateB = new Date(b.createdAt || 0).getTime();
+        return dateB - dateA;
+    });
+
+    sortedItems.forEach(item => {
+        const row = document.createElement('tr');
+        row.dataset.id = item.id;
+        const values = getColumns(item);
+        values.forEach(value => {
+            const cell = document.createElement('td');
+            cell.textContent = value;
+            row.append(cell);
+        });
+        const actionsCell = document.createElement('td');
+        actionsCell.className = 'actions';
+        actionsCell.innerHTML = '<button class="icon-btn" data-action="edit" title="Editar">✏️</button>\n            <button class="icon-btn" data-action="delete" title="Eliminar">🗑️</button>';
+        row.append(actionsCell);
+        tbody.append(row);
+    });
+}
+
+function renderStats() {
+    dom.stats.drivers.textContent = state.drivers.length;
+    dom.stats.vehicles.textContent = state.vehicles.filter(vehicle => vehicle.status === 'en_servicio').length;
+
+    const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    const recentMovements = state.movements.filter(movement => {
+        const departure = movement.departureDate ? new Date(movement.departureDate).getTime() : 0;
+        return departure >= thirtyDaysAgo;
+    });
+    dom.stats.movements.textContent = recentMovements.length;
+
+    const today = new Date().setHours(0, 0, 0, 0);
+    const upcomingMaintenance = state.maintenance.filter(item => {
+        if (!item.nextDate) return false;
+        const next = new Date(item.nextDate).setHours(0, 0, 0, 0);
+        return next >= today;
+    });
+    dom.stats.maintenance.textContent = upcomingMaintenance.length;
+}
+
+function renderRecentActivity() {
+    const events = [];
+
+    state.movements.forEach(item => {
+        events.push({
+            date: item.departureDate || item.createdAt,
+            description: `Movimiento de ${getVehicleName(item.vehicleId)} hacia ${item.destination}`
+        });
+    });
+
+    state.fuel.forEach(item => {
+        events.push({
+            date: item.date || item.createdAt,
+            description: `Carguío de ${item.liters.toLocaleString('es-ES', { maximumFractionDigits: 1 })} L para ${getVehicleName(item.vehicleId)}`
+        });
+    });
+
+    state.maintenance.forEach(item => {
+        events.push({
+            date: item.date || item.createdAt,
+            description: `Mantenimiento (${item.type}) registrado para ${getVehicleName(item.vehicleId)}`
+        });
+    });
+
+    const sorted = events
+        .filter(event => event.date)
+        .sort((a, b) => new Date(b.date) - new Date(a.date))
+        .slice(0, 6);
+
+    dom.recentActivity.innerHTML = '';
+
+    if (!sorted.length) {
+        const li = document.createElement('li');
+        li.textContent = 'No hay actividades recientes.';
+        dom.recentActivity.append(li);
+        return;
+    }
+
+    sorted.forEach(event => {
+        const li = document.createElement('li');
+        const spanDescription = document.createElement('span');
+        spanDescription.textContent = event.description;
+
+        const spanDate = document.createElement('span');
+        spanDate.style.color = 'var(--color-muted)';
+        spanDate.textContent = formatDateTime(event.date);
+
+        li.append(spanDescription, spanDate);
+        dom.recentActivity.append(li);
+    });
+}
+
+function generateId() {
+    if (window.crypto?.randomUUID) {
+        return window.crypto.randomUUID();
+    }
+    return `id-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function getVehicleName(id) {
+    const vehicle = state.vehicles.find(vehicle => vehicle.id === id);
+    if (!vehicle) return 'Vehículo no encontrado';
+    return `${vehicle.plate} · ${vehicle.brand}`;
+}
+
+function getDriverName(id) {
+    const driver = state.drivers.find(driver => driver.id === id);
+    if (!driver) return 'Conductor no asignado';
+    return driver.name;
+}
+
+function formatDate(value) {
+    if (!value) return '—';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return date.toLocaleDateString('es-ES', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric'
+    });
+}
+
+function formatDateTime(value) {
+    if (!value) return '—';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return date.toLocaleString('es-ES', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+    });
+}
+
+function formatCurrency(value) {
+    return new Intl.NumberFormat('es-ES', {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 2
+    }).format(value || 0);
+}
+
+function closeDialog(dialog) {
+    if (!dialog) return;
+    const form = dialog.querySelector('form');
+    dialog.close();
+    if (form) {
+        form.reset();
+    }
+}
+
+function persistState() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function loadState() {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) {
+            return clone(seedData);
+        }
+        const parsed = JSON.parse(raw);
+        return {
+            drivers: parsed.drivers || [],
+            vehicles: parsed.vehicles || [],
+            movements: parsed.movements || [],
+            fuel: parsed.fuel || [],
+            maintenance: parsed.maintenance || []
+        };
+    } catch (error) {
+        console.warn('No se pudo cargar la información almacenada, usando datos iniciales.', error);
+        return clone(seedData);
+    }
+}
+
+function loadSession() {
+    try {
+        const raw = localStorage.getItem(SESSION_KEY);
+        if (!raw) return null;
+        return JSON.parse(raw);
+    } catch (error) {
+        console.warn('No se pudo cargar la sesión previa.', error);
+        return null;
+    }
+}
+
+function saveSession(value) {
+    localStorage.setItem(SESSION_KEY, JSON.stringify(value));
+}
+
+function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+function getEntityByModalId(modalId) {
+    const entry = Object.entries(entityConfig).find(([, config]) => config.modal.id === modalId);
+    return entry ? entry[0] : null;
+}
+
+function createSeedData() {
+    const now = new Date();
+    const isoNow = now.toISOString();
+    const formatDateOnly = daysAgo => {
+        const date = new Date(now);
+        date.setDate(date.getDate() - daysAgo);
+        return date.toISOString().slice(0, 10);
+    };
+    const formatDateTimeString = daysAgo => {
+        const date = new Date(now);
+        date.setDate(date.getDate() - daysAgo);
+        return date.toISOString().slice(0, 16);
+    };
+
+    return {
+        drivers: [
+            { id: 'drv-1', name: 'Laura Pérez', licenseNumber: 'CL-98234', phone: '+56 9 1234 5678', email: 'laura.perez@transporte.cl', createdAt: isoNow },
+            { id: 'drv-2', name: 'Andrés Muñoz', licenseNumber: 'CL-54231', phone: '+56 9 8765 4321', email: 'andres.munoz@transporte.cl', createdAt: isoNow },
+            { id: 'drv-3', name: 'Carolina Díaz', licenseNumber: 'CL-76890', phone: '+56 9 5555 7890', email: 'carolina.diaz@transporte.cl', createdAt: isoNow }
+        ],
+        vehicles: [
+            { id: 'veh-1', plate: 'AB-CD-12', brand: 'Mercedes-Benz', model: 'Sprinter', year: 2020, capacity: '3.5 t', status: 'en_servicio', createdAt: isoNow },
+            { id: 'veh-2', plate: 'EF-GH-34', brand: 'Volvo', model: 'FH16', year: 2018, capacity: '25 t', status: 'en_servicio', createdAt: isoNow },
+            { id: 'veh-3', plate: 'IJ-KL-56', brand: 'Scania', model: 'P320', year: 2019, capacity: '18 t', status: 'mantenimiento', createdAt: isoNow }
+        ],
+        movements: [
+            {
+                id: 'mov-1',
+                vehicleId: 'veh-1',
+                driverId: 'drv-1',
+                origin: 'Santiago',
+                destination: 'Valparaíso',
+                departureDate: formatDateTimeString(2),
+                arrivalDate: formatDateTimeString(1),
+                notes: 'Entrega programada en horario matutino',
+                createdAt: isoNow
+            },
+            {
+                id: 'mov-2',
+                vehicleId: 'veh-2',
+                driverId: 'drv-2',
+                origin: 'Concepción',
+                destination: 'Temuco',
+                departureDate: formatDateTimeString(5),
+                arrivalDate: formatDateTimeString(4),
+                notes: 'Carga de materiales de construcción',
+                createdAt: isoNow
+            }
+        ],
+        fuel: [
+            {
+                id: 'fuel-1',
+                vehicleId: 'veh-1',
+                driverId: 'drv-1',
+                date: formatDateOnly(1),
+                liters: 120,
+                cost: 580,
+                station: 'Copec Kennedy',
+                createdAt: isoNow
+            },
+            {
+                id: 'fuel-2',
+                vehicleId: 'veh-2',
+                driverId: 'drv-2',
+                date: formatDateOnly(3),
+                liters: 300,
+                cost: 1350,
+                station: 'Shell Paicaví',
+                createdAt: isoNow
+            }
+        ],
+        maintenance: [
+            {
+                id: 'mnt-1',
+                vehicleId: 'veh-3',
+                date: formatDateOnly(7),
+                type: 'Cambio de aceite',
+                description: 'Reemplazo de filtro y aceite sintético',
+                cost: 220,
+                nextDate: formatDateOnly(-83),
+                createdAt: isoNow
+            },
+            {
+                id: 'mnt-2',
+                vehicleId: 'veh-2',
+                date: formatDateOnly(20),
+                type: 'Revisión general',
+                description: 'Chequeo de frenos y neumáticos',
+                cost: 480,
+                nextDate: formatDateOnly(-40),
+                createdAt: isoNow
+            }
+        ]
+    };
+}


### PR DESCRIPTION
## Summary
- build a single-page fleet management dashboard with authentication, navigation and CRUD modals for conductores, vehículos, movimientos, combustible y mantenimiento
- implement client-side state management with localStorage, estadísticas dinámicas y registros de actividad
- add responsive styling and documentation that explains uso, estructura y personalización de la app

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cde6b9b9f883228b79bc3af38d33ea